### PR TITLE
fix: cookies usage on edge functions.

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,22 +1,22 @@
 'use server'
 import 'server-only'
-import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import { createServerActionClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
 import { Database } from '@/lib/db_types'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 
 import { type Chat } from '@/lib/types'
-import { auth } from '@/auth'
-
-const supabase = createServerComponentClient<Database>({ cookies })
 
 export async function getChats(userId?: string | null) {
   if (!userId) {
     return []
   }
-
   try {
+    const readOnlyRequestCookies = cookies()
+    const supabase = createServerActionClient<Database>({
+      cookies: () => readOnlyRequestCookies
+    })
     const { data } = await supabase
       .from('chats')
       .select('payload')
@@ -31,6 +31,10 @@ export async function getChats(userId?: string | null) {
 }
 
 export async function getChat(id: string) {
+  const readOnlyRequestCookies = cookies()
+  const supabase = createServerActionClient<Database>({
+    cookies: () => readOnlyRequestCookies
+  })
   const { data } = await supabase
     .from('chats')
     .select('payload')
@@ -42,6 +46,10 @@ export async function getChat(id: string) {
 
 export async function removeChat({ id, path }: { id: string; path: string }) {
   try {
+    const readOnlyRequestCookies = cookies()
+    const supabase = createServerActionClient<Database>({
+      cookies: () => readOnlyRequestCookies
+    })
     await supabase.from('chats').delete().eq('id', id).throwOnError()
 
     revalidatePath('/')
@@ -55,12 +63,11 @@ export async function removeChat({ id, path }: { id: string; path: string }) {
 
 export async function clearChats() {
   try {
-    const session = await auth()
-    await supabase
-      .from('chats')
-      .delete()
-      .eq('user_id', session?.user.id)
-      .throwOnError()
+    const readOnlyRequestCookies = cookies()
+    const supabase = createServerActionClient<Database>({
+      cookies: () => readOnlyRequestCookies
+    })
+    await supabase.from('chats').delete().throwOnError()
     revalidatePath('/')
     return redirect('/')
   } catch (error) {
@@ -72,6 +79,10 @@ export async function clearChats() {
 }
 
 export async function getSharedChat(id: string) {
+  const readOnlyRequestCookies = cookies()
+  const supabase = createServerActionClient<Database>({
+    cookies: () => readOnlyRequestCookies
+  })
   const { data } = await supabase
     .from('chats')
     .select('payload')
@@ -88,6 +99,10 @@ export async function shareChat(chat: Chat) {
     sharePath: `/share/${chat.id}`
   }
 
+  const readOnlyRequestCookies = cookies()
+  const supabase = createServerActionClient<Database>({
+    cookies: () => readOnlyRequestCookies
+  })
   await supabase
     .from('chats')
     .update({ payload: payload as any })

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -11,7 +11,10 @@ export async function GET(request: Request) {
   const code = requestUrl.searchParams.get('code')
 
   if (code) {
-    const supabase = createRouteHandlerClient({ cookies })
+    const readOnlyRequestCookies = cookies()
+    const supabase = createRouteHandlerClient({
+      cookies: () => readOnlyRequestCookies
+    })
     await supabase.auth.exchangeCodeForSession(code)
   }
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -8,7 +8,7 @@ import { Database } from '@/lib/db_types'
 import { auth } from '@/auth'
 import { nanoid } from '@/lib/utils'
 
-export const runtime = 'nodejs'
+export const runtime = 'edge'
 
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY
@@ -17,10 +17,13 @@ const configuration = new Configuration({
 const openai = new OpenAIApi(configuration)
 
 export async function POST(req: Request) {
-  const supabase = createRouteHandlerClient<Database>({ cookies })
+  const readOnlyRequestCookies = cookies()
+  const supabase = createRouteHandlerClient<Database>({
+    cookies: () => readOnlyRequestCookies
+  })
   const json = await req.json()
   const { messages, previewToken } = json
-  const userId = (await auth())?.user.id
+  const userId = (await auth({ readOnlyRequestCookies }))?.user.id
 
   if (!userId) {
     return new Response('Unauthorized', {

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -4,8 +4,9 @@ import { notFound, redirect } from 'next/navigation'
 import { auth } from '@/auth'
 import { getChat } from '@/app/actions'
 import { Chat } from '@/components/chat'
+import { cookies } from 'next/headers'
 
-export const runtime = 'nodejs'
+export const runtime = 'edge'
 export const preferredRegion = 'home'
 
 export interface ChatPageProps {
@@ -17,7 +18,8 @@ export interface ChatPageProps {
 export async function generateMetadata({
   params
 }: ChatPageProps): Promise<Metadata> {
-  const session = await auth()
+  const readOnlyRequestCookies = cookies()
+  const session = await auth({ readOnlyRequestCookies })
 
   if (!session?.user) {
     return {}
@@ -30,7 +32,8 @@ export async function generateMetadata({
 }
 
 export default async function ChatPage({ params }: ChatPageProps) {
-  const session = await auth()
+  const readOnlyRequestCookies = cookies()
+  const session = await auth({ readOnlyRequestCookies })
 
   if (!session?.user) {
     redirect(`/sign-in?next=/chat/${params.id}`)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,6 +44,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         <Toaster />
         <Providers attribute="class" defaultTheme="system" enableSystem>
           <div className="flex min-h-screen flex-col">
+            {/* @ts-ignore */}
             <Header />
             <main className="flex flex-1 flex-col bg-muted/50">{children}</main>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import { nanoid } from '@/lib/utils'
 import { Chat } from '@/components/chat'
 
-export const runtime = 'nodejs'
+export const runtime = 'edge'
 
 export default function IndexPage() {
   const id = nanoid()

--- a/app/share/[id]/page.tsx
+++ b/app/share/[id]/page.tsx
@@ -6,7 +6,7 @@ import { getSharedChat } from '@/app/actions'
 import { ChatList } from '@/components/chat-list'
 import { FooterText } from '@/components/footer'
 
-export const runtime = 'nodejs'
+export const runtime = 'edge'
 export const preferredRegion = 'home'
 
 interface SharePageProps {

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -2,10 +2,12 @@ import { auth } from '@/auth'
 import { LoginButton } from '@/components/login-button'
 import { LoginForm } from '@/components/login-form'
 import { Separator } from '@/components/ui/separator'
+import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 export default async function SignInPage() {
-  const session = await auth()
+  const readOnlyRequestCookies = cookies()
+  const session = await auth({ readOnlyRequestCookies })
   // redirect to home if user is already logged in
   if (session?.user) {
     redirect('/')

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -2,10 +2,12 @@ import { auth } from '@/auth'
 import { LoginButton } from '@/components/login-button'
 import { LoginForm } from '@/components/login-form'
 import { Separator } from '@/components/ui/separator'
+import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 export default async function SignInPage() {
-  const session = await auth()
+  const readOnlyRequestCookies = cookies()
+  const session = await auth({ readOnlyRequestCookies })
   // redirect to home if user is already logged in
   if (session?.user) {
     redirect('/')

--- a/auth.ts
+++ b/auth.ts
@@ -2,9 +2,15 @@ import 'server-only'
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
 
-export const auth = async () => {
+export const auth = async ({
+  readOnlyRequestCookies
+}: {
+  readOnlyRequestCookies: ReturnType<typeof cookies>
+}) => {
   // Create a Supabase client configured to use cookies
-  const supabase = createServerComponentClient({ cookies })
+  const supabase = createServerComponentClient({
+    cookies: () => readOnlyRequestCookies
+  })
   const { data, error } = await supabase.auth.getSession()
   if (error) throw error
   return data.session

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -17,9 +17,11 @@ import { SidebarFooter } from '@/components/sidebar-footer'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { ClearHistory } from '@/components/clear-history'
 import { UserMenu } from '@/components/user-menu'
+import { cookies } from 'next/headers'
 
 export async function Header() {
-  const session = await auth()
+  const readOnlyRequestCookies = cookies()
+  const session = await auth({ readOnlyRequestCookies })
   return (
     <header className="sticky top-0 z-50 flex h-16 w-full shrink-0 items-center justify-between border-b bg-gradient-to-b from-background/10 via-background/50 to-background/80 px-4 backdrop-blur-xl">
       <div className="flex items-center">

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -3,9 +3,8 @@
 import * as React from 'react'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
 
-import { cn } from '@/lib/utils'
-import { Button, type ButtonProps } from '@/components/ui/button'
-import { IconGitHub, IconSpinner } from '@/components/ui/icons'
+import { Button } from '@/components/ui/button'
+import { IconSpinner } from '@/components/ui/icons'
 import { Input } from './ui/input'
 import { Label } from './ui/label'
 import Link from 'next/link'
@@ -45,10 +44,14 @@ export function LoginForm({
 
   const signUp = async () => {
     const { email, password } = formState
-    const { error } = await supabase.auth.signUp({
+    const { error, data } = await supabase.auth.signUp({
       email,
-      password
+      password,
+      options: { emailRedirectTo: `${location.origin}/api/auth/callback` }
     })
+
+    if (!error && !data.session)
+      toast.success('Check your inbox to confirm your email address!')
     return error
   }
 
@@ -105,7 +108,7 @@ export function LoginForm({
         <div className="mt-4 flex items-center">
           <Button disabled={isLoading}>
             {isLoading && <IconSpinner className="mr-2 animate-spin" />}
-            Sign In
+            {action === 'sign-in' ? 'Sign In' : 'Sign Up'}
           </Button>
           <p className="ml-4">
             {action === 'sign-in' ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ dependencies:
     specifier: ^2.1.6
     version: 2.1.6(react@18.2.0)(svelte@3.59.2)(vue@3.3.4)
   class-variance-authority:
-    specifier: ^0.4.0
-    version: 0.4.0(typescript@5.1.3)
+    specifier: ^0.6.1
+    version: 0.6.1
   clsx:
     specifier: ^1.2.1
     version: 1.2.1
@@ -68,6 +68,9 @@ dependencies:
   openai-edge:
     specifier: ^0.5.1
     version: 0.5.1
+  prettier-plugin-tailwindcss:
+    specifier: ^0.3.0
+    version: 0.3.0(prettier@2.8.8)
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -1803,15 +1806,10 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /class-variance-authority@0.4.0(typescript@5.1.3):
-    resolution: {integrity: sha512-74enNN8O9ZNieycac/y8FxqgyzZhZbxmCitAtAeUrLPlxjSd5zA7LfpprmxEcOmQBnaGs5hYhiSGnJ0mqrtBLQ==}
-    peerDependencies:
-      typescript: '>= 4.5.5 < 5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  /class-variance-authority@0.6.1:
+    resolution: {integrity: sha512-eurOEGc7YVx3majOrOb099PNKgO3KnKSApOprXI4BTq6bcfbqbQXPN2u+rPPmIJ2di23bMwhk0SxCCthBmszEQ==}
     dependencies:
-      typescript: 5.1.3
+      clsx: 1.2.1
     dev: false
 
   /client-only@0.0.1:
@@ -4203,11 +4201,65 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
+  /prettier-plugin-tailwindcss@0.3.0(prettier@2.8.8):
+    resolution: {integrity: sha512-009/Xqdy7UmkcTBpwlq7jsViDqXAYSOMLDrHAdTMlVZOrKfM2o9Ci7EMWTMZ7SkKBFTG04UM9F9iM2+4i6boDA==}
+    engines: {node: '>=12.17.0'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@shufo/prettier-plugin-blade': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      prettier: '>=2.2.0'
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+      prettier-plugin-twig-melody: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@shufo/prettier-plugin-blade':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+      prettier-plugin-twig-melody:
+        optional: true
+    dependencies:
+      prettier: 2.8.8
+    dev: false
+
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-    dev: true
 
   /prismjs@1.27.0:
     resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
@@ -4965,6 +5017,7 @@ packages:
     resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -56,7 +56,7 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = false
+enable_confirmations = true
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin`, `notion`, `twitch`,


### PR DESCRIPTION
Fixes #3 

It's very important at what point you call the `cookies` method for things to work correctly. 

So rather than handing the `cookies` method to the supabase client, we need to extract the value first, and then hand the supabase client a function that retrieves that value, e.g.:

```js
'use server'
import { createServerActionClient } from '@supabase/auth-helpers-nextjs'
import { cookies } from 'next/headers'
import { Database } from '@/lib/db_types'

const cookieStore = cookies()
const supabase = createServerActionClient<Database>({
  cookies: () => cookieStore
})
```