### PR TITLE
chore: rename cookieStore.

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -13,9 +13,9 @@ export async function getChats(userId?: string | null) {
     return []
   }
   try {
-    const readOnlyRequestCookies = cookies()
+    const cookieStore = cookies()
     const supabase = createServerActionClient<Database>({
-      cookies: () => readOnlyRequestCookies
+      cookies: () => cookieStore
     })
     const { data } = await supabase
       .from('chats')
@@ -31,9 +31,9 @@ export async function getChats(userId?: string | null) {
 }
 
 export async function getChat(id: string) {
-  const readOnlyRequestCookies = cookies()
+  const cookieStore = cookies()
   const supabase = createServerActionClient<Database>({
-    cookies: () => readOnlyRequestCookies
+    cookies: () => cookieStore
   })
   const { data } = await supabase
     .from('chats')
@@ -46,9 +46,9 @@ export async function getChat(id: string) {
 
 export async function removeChat({ id, path }: { id: string; path: string }) {
   try {
-    const readOnlyRequestCookies = cookies()
+    const cookieStore = cookies()
     const supabase = createServerActionClient<Database>({
-      cookies: () => readOnlyRequestCookies
+      cookies: () => cookieStore
     })
     await supabase.from('chats').delete().eq('id', id).throwOnError()
 
@@ -63,9 +63,9 @@ export async function removeChat({ id, path }: { id: string; path: string }) {
 
 export async function clearChats() {
   try {
-    const readOnlyRequestCookies = cookies()
+    const cookieStore = cookies()
     const supabase = createServerActionClient<Database>({
-      cookies: () => readOnlyRequestCookies
+      cookies: () => cookieStore
     })
     await supabase.from('chats').delete().throwOnError()
     revalidatePath('/')
@@ -79,9 +79,9 @@ export async function clearChats() {
 }
 
 export async function getSharedChat(id: string) {
-  const readOnlyRequestCookies = cookies()
+  const cookieStore = cookies()
   const supabase = createServerActionClient<Database>({
-    cookies: () => readOnlyRequestCookies
+    cookies: () => cookieStore
   })
   const { data } = await supabase
     .from('chats')
@@ -99,9 +99,9 @@ export async function shareChat(chat: Chat) {
     sharePath: `/share/${chat.id}`
   }
 
-  const readOnlyRequestCookies = cookies()
+  const cookieStore = cookies()
   const supabase = createServerActionClient<Database>({
-    cookies: () => readOnlyRequestCookies
+    cookies: () => cookieStore
   })
   await supabase
     .from('chats')

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -11,9 +11,9 @@ export async function GET(request: Request) {
   const code = requestUrl.searchParams.get('code')
 
   if (code) {
-    const readOnlyRequestCookies = cookies()
+    const cookieStore = cookies()
     const supabase = createRouteHandlerClient({
-      cookies: () => readOnlyRequestCookies
+      cookies: () => cookieStore
     })
     await supabase.auth.exchangeCodeForSession(code)
   }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -17,13 +17,13 @@ const configuration = new Configuration({
 const openai = new OpenAIApi(configuration)
 
 export async function POST(req: Request) {
-  const readOnlyRequestCookies = cookies()
+  const cookieStore = cookies()
   const supabase = createRouteHandlerClient<Database>({
-    cookies: () => readOnlyRequestCookies
+    cookies: () => cookieStore
   })
   const json = await req.json()
   const { messages, previewToken } = json
-  const userId = (await auth({ readOnlyRequestCookies }))?.user.id
+  const userId = (await auth({ cookieStore }))?.user.id
 
   if (!userId) {
     return new Response('Unauthorized', {

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -18,8 +18,8 @@ export interface ChatPageProps {
 export async function generateMetadata({
   params
 }: ChatPageProps): Promise<Metadata> {
-  const readOnlyRequestCookies = cookies()
-  const session = await auth({ readOnlyRequestCookies })
+  const cookieStore = cookies()
+  const session = await auth({ cookieStore })
 
   if (!session?.user) {
     return {}
@@ -32,8 +32,8 @@ export async function generateMetadata({
 }
 
 export default async function ChatPage({ params }: ChatPageProps) {
-  const readOnlyRequestCookies = cookies()
-  const session = await auth({ readOnlyRequestCookies })
+  const cookieStore = cookies()
+  const session = await auth({ cookieStore })
 
   if (!session?.user) {
     redirect(`/sign-in?next=/chat/${params.id}`)

--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -6,8 +6,8 @@ import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 export default async function SignInPage() {
-  const readOnlyRequestCookies = cookies()
-  const session = await auth({ readOnlyRequestCookies })
+  const cookieStore = cookies()
+  const session = await auth({ cookieStore })
   // redirect to home if user is already logged in
   if (session?.user) {
     redirect('/')

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -6,8 +6,8 @@ import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 
 export default async function SignInPage() {
-  const readOnlyRequestCookies = cookies()
-  const session = await auth({ readOnlyRequestCookies })
+  const cookieStore = cookies()
+  const session = await auth({ cookieStore })
   // redirect to home if user is already logged in
   if (session?.user) {
     redirect('/')

--- a/auth.ts
+++ b/auth.ts
@@ -3,13 +3,13 @@ import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import { cookies } from 'next/headers'
 
 export const auth = async ({
-  readOnlyRequestCookies
+  cookieStore
 }: {
-  readOnlyRequestCookies: ReturnType<typeof cookies>
+  cookieStore: ReturnType<typeof cookies>
 }) => {
   // Create a Supabase client configured to use cookies
   const supabase = createServerComponentClient({
-    cookies: () => readOnlyRequestCookies
+    cookies: () => cookieStore
   })
   const { data, error } = await supabase.auth.getSession()
   if (error) throw error

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -20,8 +20,8 @@ import { UserMenu } from '@/components/user-menu'
 import { cookies } from 'next/headers'
 
 export async function Header() {
-  const readOnlyRequestCookies = cookies()
-  const session = await auth({ readOnlyRequestCookies })
+  const cookieStore = cookies()
+  const session = await auth({ cookieStore })
   return (
     <header className="sticky top-0 z-50 flex h-16 w-full shrink-0 items-center justify-between border-b bg-gradient-to-b from-background/10 via-background/50 to-background/80 px-4 backdrop-blur-xl">
       <div className="flex items-center">


### PR DESCRIPTION
`readOnlyRequestCookies` is confusing, as in route handlers and server actions they aren't actually read only... So renaming to `cookieStore` to align with the convention here: https://nextjs.org/docs/app/api-reference/functions/cookies#cookiesgetname